### PR TITLE
Removed the required attribute from BcProductPost fields.

### DIFF
--- a/Fusionary.BigCommerce/Types/BcProductPost.cs
+++ b/Fusionary.BigCommerce/Types/BcProductPost.cs
@@ -41,7 +41,7 @@ public record BcProductPost : BcExtensionData
     /// <remarks>
     /// Required on product creation
     /// </remarks>
-    public double Weight { get; init; }
+    public double Weight { get; set; }
 
     /// <summary>
     /// Width of the product, which can be used when calculating shipping costs.


### PR DESCRIPTION

# Description
Removed the required attribute from these fields.  Although they are required for creation, they are not required in other contexts and can cause deserialization exceptions if not present (in a product fetch request for example)


